### PR TITLE
Correct openTypeOS2WeightClass to valid values

### DIFF
--- a/files/CooperHewitt-Bold.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Bold.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>711</integer>
+	<integer>700</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-BoldItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-BoldItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>712</integer>
+	<integer>700</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Book.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Book.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>705</integer>
+	<integer>400</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-BookItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-BookItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>706</integer>
+	<integer>400</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Heavy.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Heavy.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>713</integer>
+	<integer>900</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-HeavyItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-HeavyItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>714</integer>
+	<integer>900</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Light.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Light.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>703</integer>
+	<integer>200</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-LightItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-LightItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>704</integer>
+	<integer>200</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Medium.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Medium.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>707</integer>
+	<integer>500</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-MediumItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-MediumItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>708</integer>
+	<integer>500</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Semibold.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Semibold.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>709</integer>
+	<integer>600</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-SemiboldItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-SemiboldItalic.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>710</integer>
+	<integer>600</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-Thin.ufo/fontinfo.plist
+++ b/files/CooperHewitt-Thin.ufo/fontinfo.plist
@@ -127,7 +127,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>701</integer>
+	<integer>100</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>

--- a/files/CooperHewitt-ThinItalic.ufo/fontinfo.plist
+++ b/files/CooperHewitt-ThinItalic.ufo/fontinfo.plist
@@ -127,7 +127,7 @@
 	<key>openTypeOS2VendorID</key>
 	<string>VLLG</string>
 	<key>openTypeOS2WeightClass</key>
-	<integer>702</integer>
+	<integer>100</integer>
 	<key>openTypeOS2WidthClass</key>
 	<integer>5</integer>
 	<key>openTypeOS2WinAscent</key>


### PR DESCRIPTION
The OS2.usWeightClass values should be the multiples of 100 defined in http://www.microsoft.com/typography/otspec/os2.htm#wtc
